### PR TITLE
Placehold the registry username and hide MySQL port

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -2,7 +2,7 @@
 service: kamal-wordpress
 
 # Name of the container image.
-image:  liltechnomancer/kamal-wordpress
+image:  REGISTRY_USERNAME/kamal-wordpress
 
 # Deploy to these servers.
 servers:
@@ -16,7 +16,7 @@ servers:
 
 env:
   clear:
-    WORDPRESS_DB_HOST: YOUR_SERVER_IP
+    WORDPRESS_DB_HOST: kamal-wordpress-db:3306
     WORDPRESS_DB_USER: wordpress
     WORDPRESS_DB_NAME: wordpress
   secret:
@@ -40,7 +40,7 @@ proxy:
 registry:
   # Specify the registry server, if you're not using Docker Hub
   # server: registry.digitalocean.com / ghcr.io / ...
-  username: liltechnomancer
+  username: REGISTRY_USERNAME
 
   # Always use an access token rather than real password (pulled from .kamal/secrets).
   password:
@@ -55,7 +55,7 @@ accessories:
   db:
     image: mysql:5.7
     host: YOUR_SERVER_IP
-    port: 3306
+    port: "127.0.0.1:3306:3306"
     env:
       clear:
         MYSQL_DATABASE: wordpress


### PR DESCRIPTION
Thanks for this repo. I was able to get Wordpress up and running. Mostly. I haven't really tested it much. Here are some things that I think could be useful.

- The registry username/password would be provided by the person cloning the repo. Replaced liltechnomancer username with a placeholder.
- `port: 3306` exposes that port to the world for the db accessory. That can be restricted to the server with `127.0.0.1:3306:3306`.
- Kamal sets up container names for accessories that you can reference as `<service>-<accessory_key>`. So WORDPRESS_DB_HOST can just be `kamal-wordpress-db`. I don't know if the port is necessary, but I added it.

To be honest, I'm not sure if all that's correct, but it's working for me for now.